### PR TITLE
Add workflow_call trigger to claude.yml

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,7 @@ on:
     types: [opened]
   pull_request_review:
     types: [submitted]
+  workflow_call:
 
 concurrency:
   group: claude-${{ github.event.issue.number || github.event.pull_request.number }}


### PR DESCRIPTION
This pull request introduces a minor update to the GitHub Actions workflow configuration. The change adds support for triggering the workflow via `workflow_call`, allowing other workflows to invoke this workflow directly.

* GitHub Actions workflow configuration: Added the `workflow_call` trigger to `.github/workflows/claude.yml` to enable invocation from other workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD infrastructure configuration to enhance workflow orchestration capabilities. No end-user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->